### PR TITLE
Request errors are now instanceof Error

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -2,6 +2,7 @@
 var request = require('request');
 var url = require('url');
 var colors = require('colors');
+var RequestError = require('./request_error');
 
 
 // Inits class and saves settings in it
@@ -79,34 +80,9 @@ lollib.prototype.makeRequest = function (url, cb){
 
 					cb(e);
 				}
-			} else if(res.statusCode == 404){
-				cb({
-					status: {
-						message: 'Not found',
-						code: 404
-					}
-				});
-			} else if(res.statusCode == 429){
-				cb({
-					status: {
-						message: 'Rate limit exceeded',
-						code: 429
-					}
-				});
-			} else if(res.statusCode == 500){
-				cb({
-					status: {
-						message: 'Internal server error',
-						code: 500
-					}
-				})
 			} else {
-				cb({
-					status: {
-						message: 'Unknown error',
-						code: 0
-					}
-				})
+				err = new RequestError(url, res.statusCode);
+				cb(err);
 			}
 
 		}

--- a/lib/request_error.js
+++ b/lib/request_error.js
@@ -1,0 +1,39 @@
+var RequestError = function(url, statusCode){
+	Error.call(this);
+	Error.captureStackTrace(this, RequestError);
+
+	this.name = 'RequestError';
+	this.url = url;
+	this.statusCode = statusCode;
+	this.message = 'HTTP Status Code ' + statusCode + ' received when requesting ' + url;
+
+	this.populateStatus();
+};
+RequestError.prototype = new Error();
+RequestError.prototype.constructor = RequestError;
+
+RequestError.prototype.populateStatus = function(){
+	if(this.statusCode === 404){
+		this.status = {
+			message: 'Not found',
+			code: this.statusCode
+		};
+	} else if(this.statusCode === 429){
+		this.status = {
+			message: 'Rate limit exceeded',
+			code: this.statusCode
+		};
+	} else if(this.statusCode === 500){
+		this.status = {
+			message: 'Internal server error',
+			code: this.statusCode
+		};
+	} else {
+		this.status = {
+			message: 'Unknown error',
+			code: 0
+		};
+	}
+};
+
+module.exports = RequestError;


### PR DESCRIPTION
I've updated the error object created in irelia.makeRequest when an unsuccessful status code is received so that it's an instanceof Error (as well as RequestError).

I've done this because I pass the error object up the callback chain and another library that I am using (coffee-resque) requires that errors be an instanceof Error.

Thoughts?
