### PR TITLE
Missing api route

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -133,6 +133,16 @@ lollib.prototype.getLeagueBySummonerId = function (region, summonerId, cb){
 	this.makeRequest(url, cb);
 
 };
+lollib.prototype.getLeagueEntryBySummonerId = function (region, summonerId, cb){
+
+	var url = this.generateUrl({
+		region: region,
+		path: '/v2.3/league/by-summoner/' + summonerId + '/entry',
+	});
+
+	this.makeRequest(url, cb);
+
+};
 
 
 lollib.prototype.getSummaryStatsBySummonerId = function (region, summonerId, season, cb){


### PR DESCRIPTION
Currently the wrapper is missing the the league entries route this pull adds it

Route: /api/lol/{region}/v2.3/league/by-summoner/{summonerId}/entry
Riot doc: http://developer.riotgames.com/api/methods#!/540/1700
