### PR TITLE
Fixed missing comma in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ var Irelia = require('irelia');
 var irelia = new Irelia({
 	secure: true,
 	host: 'prod.api.pvp.net',
-	path: '/api/lol/'
+	path: '/api/lol/',
 	key: 'your_key_goes_here',
 	debug: true
 });


### PR DESCRIPTION
The demo code was missing a comma after: path: '/api/lol/' under "Usage". Now it should run correctly if pasted into a JS file.